### PR TITLE
fix:静态服务器路径错误导致栈溢出

### DIFF
--- a/example/devServer.js
+++ b/example/devServer.js
@@ -15,7 +15,7 @@ app.use(KoaCompress({
     threshold: 2048,
     flush: require('zlib').Z_SYNC_FLUSH
 }));
-app.use(KoaStatic(path.join(__dirname, '../')), {
+app.use(KoaStatic(path.join(__dirname, '../dist')), {
     maxAge: 365 * 24 * 60 * 60
 });
 

--- a/example/index.html
+++ b/example/index.html
@@ -51,7 +51,7 @@
         <button id="btn3">click me3</button>
         <button id="btn4">click me4</button>
     </div>
-    <script src="./dist/tracker.min.js"></script>
+    <script src="./tracker.min.js"></script>
     <script>
         Tracker
             .config({


### PR DESCRIPTION
node: v10.7.0
运行项目后发现栈溢出报错。
经排查，是 koa-static-cache 插件路径配置为了项目的根路径导致的。